### PR TITLE
Refactor: Simplify shell verification params and clarify usage

### DIFF
--- a/.cursor/rules/ghx.mdc
+++ b/.cursor/rules/ghx.mdc
@@ -1,5 +1,5 @@
 ---
-description: Search GitHub
+description: GitHub Examples Searcher. Load when user requests "Search GitHub" or "Search GitHub for Examples"
 globs: 
 alwaysApply: false
 ---

--- a/.cursor/rules/mermaid.mdc
+++ b/.cursor/rules/mermaid.mdc
@@ -1,5 +1,5 @@
 ---
-description: Diagram Creator. Load when the user wants to create a diagram.
+description: Diagram Creator. Load when the user requests "Create a diagram".
 globs:
 alwaysApply: false
 ---

--- a/.cursor/rules/pr.mdc
+++ b/.cursor/rules/pr.mdc
@@ -1,0 +1,11 @@
+---
+description: PR creator. Load when the user requests to "Create a Pull Request" or "Create a PR"
+globs:
+alwaysApply: false
+---
+
+Write a summary of everything from this conversation to .pr/pr-body-file-<branch-name>.md (use the actual branch name)
+Use the gh cli to create a Pull Request, fill the title,etc and use --body-file ./tmp/pr-body-file-<branch-name>.md
+
+Example:
+gh pr create --title "feat: Enforce normalized, dash-separated, lowercase labels for all shells" --body-file tmp/pr-body-file-fix-label-sanitization.md --fill

--- a/.cursor/rules/repomix.mdc
+++ b/.cursor/rules/repomix.mdc
@@ -1,8 +1,11 @@
 ---
-description: Pack a directory
+description: File packer. Load when a user requests "Pack files/directory/pattern"
 globs:
 alwaysApply: false
 ---
+
+> Note: Always use `-o tmp/<filename>` so that the file is saved to a "tmp" directory in the current project.
+
 Usage: repomix [options] [directories...]
 
 Repomix - Pack your repository into a single AI-friendly file

--- a/.cursor/rules/wrangler.mdc
+++ b/.cursor/rules/wrangler.mdc
@@ -1,5 +1,5 @@
 ---
-description: Use wrangler
+description: Wrangler runner. Load when a user requests to run a wrangler command.
 globs: 
 alwaysApply: false
 ---

--- a/.cursor/rules/wt.mdc
+++ b/.cursor/rules/wt.mdc
@@ -3,6 +3,10 @@ description: Worktree manager. Load when a user requests "Create a worktree", "p
 globs: 
 alwaysApply: false
 ---
+
+To manage worktrees, use the `wt` cli
+If it fails to run, you may need to install `https://www.npmjs.com/package/@johnlindquist/worktree` globally
+
 Usage: wt [options] [command]
 
 Manage git worktrees and open them in the Cursor editor.
@@ -28,3 +32,12 @@ Commands:
                                       number and create a worktree.
   config                              Manage CLI configuration settings.
   help [command]                      display help for command
+
+
+Examples:
+
+wt new feature/login
+wt new feature/chat --checkout
+wt new feature/auth -p ./auth-worktree
+wt new feature/deps -i pnpm
+wt new feature/vscode -e code

--- a/.cursor/rules/wt.mdc
+++ b/.cursor/rules/wt.mdc
@@ -1,5 +1,5 @@
 ---
-description: Create a worktree
+description: Worktree manager. Load when a user requests "Create a worktree", "purge worktrees", etc.
 globs: 
 alwaysApply: false
 ---

--- a/API.md
+++ b/API.md
@@ -40,7 +40,7 @@ On failure, returns an error object, potentially including `error`, `status`, `c
 
 ### `start_shell_with_verification`
 
-Starts a background process with verification (pattern, timeout, retries).
+Starts a background process with verification (pattern, timeout, retries). Rarely used, prefer `start_shell` unless the user explicitly uses the words "to verify that the shell has started".
 
 **Parameters:**
 

--- a/src/toolDefinitions.ts
+++ b/src/toolDefinitions.ts
@@ -79,9 +79,9 @@ export function registerToolDefinitions(server: McpServer): void {
 
 	server.tool(
 		"start_shell_with_verification",
-		"Starts a shell with verification (pattern, timeout, retries). Useful for dev servers, tests, or scripts that print a specific line when ready. Returns monitoring commands and all shell output for inspection.",
+		"Starts a shell with verification (pattern, timeout, retries). Returns monitoring commands and all shell output. IMPORTANT: This tool is rarely used. Prefer 'start_shell' unless explicitly requested by the user to verify successful startup.",
 		shape(schemas.StartShellWithVerificationParams.shape),
-		(params: schemas.StartProcessWithVerificationParamsType) => {
+		(params: z.infer<typeof schemas.StartShellWithVerificationParams>) => {
 			const cwdForLabel = params.workingDirectory;
 			const effectiveLabel = params.label || `${cwdForLabel}:${params.command}`;
 			const hostValue = params.host;

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -89,7 +89,7 @@ export const StartShellWithVerificationParams = z.object(
 			.string()
 			.optional()
 			.describe(
-				"Optional regex pattern to match in shell output to verify successful startup. For example, 'running on port 3000' or 'localhost'.",
+				"Important: Rarely used. Optional regex pattern to match in shell output to verify successful startup. For example, 'running on port 3000' or 'localhost'.",
 			),
 		verification_timeout_ms: z
 			.number()
@@ -98,7 +98,7 @@ export const StartShellWithVerificationParams = z.object(
 			.optional()
 			.default(cfg.defaultVerificationTimeoutMs)
 			.describe(
-				"Milliseconds to wait for the verification pattern in shell output. -1 disables the timer (default).",
+				"IMPORTANT: Rarely used. Milliseconds to wait for the verification pattern in shell output. -1 disables the timer (default).",
 			),
 		retry_delay_ms: z
 			.number()
@@ -117,10 +117,7 @@ export const StartShellWithVerificationParams = z.object(
 				`Optional maximum number of restart attempts for a crashed shell (default: ${cfg.maxRetries}). 0 disables restarts.`,
 			),
 	}),
-);
-export type StartProcessWithVerificationParamsType = z.infer<
-	typeof StartShellWithVerificationParams
->;
+).describe("Parameters for starting a shell with verification. IMPORTANT: This is rarely used. Prefer 'StartShellParams' unless the user explicitly requests to verify successful shell startup.");
 
 export const CheckProcessStatusParams = z.object(
 	shape({


### PR DESCRIPTION
This series of changes aimed to simplify the usage of shell verification parameters and clarify their intended use.

*   Removed the `StartProcessWithVerificationParamsType` alias in `src/types/schemas.ts`. The type is now directly inferred using `z.infer<typeof schemas.StartShellWithVerificationParams>` in `src/toolDefinitions.ts`.
*   Updated the descriptions for `StartShellWithVerificationParams` in `src/types/schemas.ts` and the `start_shell_with_verification` tool definition in `src/toolDefinitions.ts`. The updated descriptions now more clearly state that these options are rarely used and should only be employed when explicit verification of shell startup is requested by the user.
*   The user also refined the descriptions for the `verification_pattern` and `verification_timeout_ms` fields within `StartShellWithVerificationParams` in `src/types/schemas.ts` to further emphasize that they are part of a rarely used feature set. 